### PR TITLE
riscv:pbmt:Support CONFIG_STD_SVPBMT

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -418,6 +418,10 @@ config THEAD_ISA
 	bool "T-HEAD extension ISA in AFLAGS with -march=_xtheadc"
 	default n
 
+config STD_SVPBMT
+	bool "Use standard SVPBMT"
+	default y
+
 endmenu
 
 menu "Kernel features"

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -420,7 +420,7 @@ config THEAD_ISA
 
 config STD_SVPBMT
 	bool "Use standard SVPBMT"
-	default y
+	default n
 
 endmenu
 

--- a/arch/riscv/include/asm/pgtable-bits.h
+++ b/arch/riscv/include/asm/pgtable-bits.h
@@ -25,11 +25,19 @@
 #define _PAGE_SOFT      (1 << 8)    /* Reserved for software */
 
 /* T-HEAD C9xx extend */
+#ifdef CONFIG_STD_SVPBMT
+#define _PAGE_SEC	(0UL << 00)   /* Security */
+#define _PAGE_SHARE	(0UL << 00)   /* Shareable */
+#define _PAGE_BUF	(0UL << 00)   /* Bufferable */
+#define _PAGE_CACHE	(0UL << 00)   /* Cacheable */
+#define _PAGE_SO	(1UL << 62)   /* Strong Order */
+#else
 #define _PAGE_SEC	(1UL << 59)   /* Security */
 #define _PAGE_SHARE	(1UL << 60)   /* Shareable */
 #define _PAGE_BUF	(1UL << 61)   /* Bufferable */
 #define _PAGE_CACHE	(1UL << 62)   /* Cacheable */
 #define _PAGE_SO	(1UL << 63)   /* Strong Order */
+#endif
 
 #define _PAGE_SPECIAL   _PAGE_SOFT
 #define _PAGE_TABLE     _PAGE_PRESENT

--- a/arch/riscv/include/asm/pgtable.h
+++ b/arch/riscv/include/asm/pgtable.h
@@ -432,8 +432,13 @@ static inline pgprot_t pgprot_noncached(pgprot_t _prot)
 {
 	unsigned long prot = pgprot_val(_prot);
 
+#ifdef CONFIG_STD_SVPBMT
+	prot &= ~BIT(61);
+	prot |= _PAGE_SO;
+#else
 	prot &= ~(_PAGE_CACHE | _PAGE_BUF);
 	prot |= _PAGE_SO;
+#endif
 
 	return __pgprot(prot);
 }
@@ -443,7 +448,12 @@ static inline pgprot_t pgprot_writecombine(pgprot_t _prot)
 {
 	unsigned long prot = pgprot_val(_prot);
 
+#ifdef CONFIG_STD_SVPBMT
+	prot &= ~_PAGE_SO;
+	prot |= BIT(61);
+#else
 	prot &= ~(_PAGE_CACHE | _PAGE_BUF);
+#endif
 
 	return __pgprot(prot);
 }


### PR DESCRIPTION
The new THEAD XuanTie C9xx CPU has standard SVPBMT.